### PR TITLE
Update libvorbis_build.bash

### DIFF
--- a/libvorbis_build.bash
+++ b/libvorbis_build.bash
@@ -1,3 +1,8 @@
+#! /bin/sh
+
+# exit when any command fails
+set -e
+
 # Config
 IDZ_VORBIS_VERSION=1.3.5
 IDZ_OGG_VERSION=$IDZ_OGG_VERSION


### PR DESCRIPTION
autogen.sh didn't finish successful and left the default `config` behind. That's why the build failed in the end.
This change makes the script exit on errors